### PR TITLE
README.md: add --recursive to git clone, because of submodules

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ This emulates Fn key of your laptop on any keyboard, and a lot more.
 
 ### Others
 ```sh
-git clone https://github.com/hirak99/keyshift
+git clone --recursive https://github.com/hirak99/keyshift
 cd keyshift
 
 # Note: You may need to install "boost" for your distribution if the build fails.


### PR DESCRIPTION
In this PR, I am adding a --recursive flag to git module in the README.md doc, because src/thirdparty/digestpp is a submodule and needs to be cloned as well.